### PR TITLE
Don't trim leading whitespace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,7 @@ fn extract_inner_doc<P>(path: P) -> String where P: AsRef<Path> {
   content.lines()
     .skip_while(|l| !l.starts_with("//!"))
     .take_while(|l| l.starts_with("//!"))
-    .map(|l| format!("{}\n", l.trim_start_matches("//!").trim_start()))
+    .map(|l| format!("{}\n", l.trim_start_matches("//!")))
     .collect()
 }
 


### PR DESCRIPTION
Docs can be whitespace-sensitive (nested lists in markdown, or code blocks).

Looking at the README in [warmy](https://github.com/phaazon/warmy), you can see flattened lists and wrongly-formatted code blocks (see [here](https://github.com/phaazon/warmy/blob/5ab780102b0ed5d43785fe7e737f4987e53b9d21/README.md#the-loadload-method)).