### PR TITLE
[#15] feat: annotate rust code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ a PR!
 This is likely to be the hidden documentation feature from `rustdoc`. To fix this problem,
 re-run with:
 
-```rust
-pub fn add(a: u8, b: u8) {
-  a + b
-}
-```
-
 ```text
 cargo sync-readme -z
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ First, this tool will respect what you put in your `Cargo.toml`. There is a spec
 Once you have put the annotation in your *readme* file, just run the command without argument to
 perform the synchronization:
 
-```
+```text
 cargo sync-readme
 ```
 
@@ -88,7 +88,13 @@ a PR!
 This is likely to be the hidden documentation feature from `rustdoc`. To fix this problem,
 re-run with:
 
+```rust
+pub fn add(a: u8, b: u8) {
+  a + b
+}
 ```
+
+```text
 cargo sync-readme -z
 ```
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,15 @@
+edition = "2018"
+
+fn_args_layout = "Tall"
+force_explicit_abi = true
+hard_tabs = false
+max_width = 100
+merge_derives = true
+newline_style = "Unix"
+remove_nested_parens = true
+reorder_imports = true
+reorder_modules = true
+tab_spaces = 2
+use_field_init_shorthand = true
+use_small_heuristics = "Default"
+use_try_shorthand = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,14 @@ mod tests {
   }
 
   #[test]
+  fn annotate_default_code_blocks_windows() {
+    let doc = "//!```\r\n//!fn add(a: u8, b: u8) -> u8 { a + b }\r\n//!```";
+    let output = transform_inner_doc(doc, false, true);
+
+    assert_eq!(output, "```rust\r\nfn add(a: u8, b: u8) -> u8 { a + b }\r\n```\r\n".to_owned());
+  }
+
+  #[test]
   fn does_not_annotate_annotated_code_blocks() {
     let doc = "//!```text\n//!echo Hello, World!\n//!```";
     let output = transform_inner_doc(doc, false, false);
@@ -443,10 +451,10 @@ mod tests {
   }
 
   #[test]
-  fn annotate_default_code_blocks_windows() {
-    let doc = "//!```\r\n//!fn add(a: u8, b: u8) -> u8 { a + b }\r\n//!```";
+  fn does_not_annotate_annotated_code_blocks_windows() {
+    let doc = "//!```text\r\n//!echo Hello, World!\r\n//!```";
     let output = transform_inner_doc(doc, false, true);
 
-    assert_eq!(output, "```rust\r\nfn add(a: u8, b: u8) -> u8 { a + b }\r\n```\r\n".to_owned());
+    assert_eq!(output, "```text\r\necho Hello, World!\r\n```\r\n".to_owned());
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@
 //! Once you have put the annotation in your *readme* file, just run the command without argument to
 //! perform the synchronization:
 //!
-//! ```
+//! ```text
 //! cargo sync-readme
 //! ```
 //!
@@ -85,8 +85,14 @@
 //!
 //! This is likely to be the hidden documentation feature from `rustdoc`. To fix this problem,
 //! re-run with:
-//!
+//! 
 //! ```
+//! pub fn add(a: u8, b: u8) {
+//!   a + b
+//! }
+//! ```
+//!
+//! ```text
 //! cargo sync-readme -z
 //! ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,43 +97,39 @@ use std::process;
 use structopt::StructOpt;
 
 use cargo_sync_readme::{
-  Manifest, PreferDocFrom, extract_inner_doc, read_readme, transform_readme
+  extract_inner_doc, read_readme, transform_readme, Manifest, PreferDocFrom,
 };
 
 #[derive(Debug, StructOpt)]
 #[structopt(author)]
 enum CliOpt {
   #[structopt(
-    about = "Generate a Markdown section in your README based on your Rust documentation.",
+    about = "Generate a Markdown section in your README based on your Rust documentation."
   )]
   SyncReadme {
     #[structopt(
       short = "z",
       long,
-      help = "Show Rust hidden documentation lines in the generated README.",
+      help = "Show Rust hidden documentation lines in the generated README."
     )]
     show_hidden_doc: bool,
 
     #[structopt(
       short = "f",
       long,
-      help = "Set to either `bin` or `lib` to instruct sync-readme which file it should read documentation from.",
+      help = "Set to either `bin` or `lib` to instruct sync-readme which file it should read documentation from."
     )]
     prefer_doc_from: Option<PreferDocFrom>,
 
     #[structopt(
       long,
-      help = "Generate documentation with CRLF for Windows-style line endings. This will not affect the already present newlines.",
+      help = "Generate documentation with CRLF for Windows-style line endings. This will not affect the already present newlines."
     )]
     crlf: bool,
 
-    #[structopt(
-      short,
-      long,
-      help = "Check whether the README is synchronized.",
-    )]
+    #[structopt(short, long, help = "Check whether the README is synchronized.")]
     check: bool,
-  }
+  },
 }
 
 const CANNOT_FIND_ENTRY_POINT_ERR_STR: &str = "\
@@ -145,7 +141,12 @@ If you’re in the special situation where your crate defines both a binary and 
 consider using the -f option to hint sync-readme which file it should read the documentation from.";
 
 fn main() {
-  let CliOpt::SyncReadme { show_hidden_doc, prefer_doc_from, crlf, check } = CliOpt::from_args();
+  let CliOpt::SyncReadme {
+    show_hidden_doc,
+    prefer_doc_from,
+    crlf,
+    check,
+  } = CliOpt::from_args();
 
   if let Ok(pwd) = current_dir() {
     match Manifest::find_manifest(pwd) {
@@ -155,11 +156,8 @@ fn main() {
         if let Some(entry_point) = entry_point {
           let doc = extract_inner_doc(entry_point, show_hidden_doc, crlf);
           let readme_path = manifest.readme();
-          let transformation =
-              read_readme(&readme_path)
-                  .and_then(|readme|
-                      transform_readme(&readme, doc, crlf).map(|new| (readme, new))
-                  );
+          let transformation = read_readme(&readme_path)
+            .and_then(|readme| transform_readme(&readme, doc, crlf).map(|new| (readme, new)));
 
           match transformation {
             Ok((ref old_readme, ref new_readme)) if check => {
@@ -174,7 +172,7 @@ fn main() {
               let _ = file.write_all(new_readme.as_bytes());
             }
 
-            Err(e) => eprintln!("{}", e)
+            Err(e) => eprintln!("{}", e),
           }
         } else {
           eprintln!("{}", CANNOT_FIND_ENTRY_POINT_ERR_STR);
@@ -192,4 +190,3 @@ fn main() {
     process::exit(1);
   }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,12 +85,6 @@
 //!
 //! This is likely to be the hidden documentation feature from `rustdoc`. To fix this problem,
 //! re-run with:
-//! 
-//! ```
-//! pub fn add(a: u8, b: u8) {
-//!   a + b
-//! }
-//! ```
 //!
 //! ```text
 //! cargo sync-readme -z


### PR DESCRIPTION
closes #15

Please have a look at this solution, I had to split the modification and filtering of lists into to separate steps and collects since I otherwise encountered the problem described in the issue.

I will add tests when we have an acceptable and idiomatic solution.

I think I would like to somehow unify the handling of the code block state, but I am not sure how. Currently the annotation function and stripping of hidden doc tests have some code duplication. 