### PR TITLE
Implement initial support for intralinks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -39,16 +39,18 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 name = "cargo-sync-readme"
 version = "1.0.0"
 dependencies = [
+ "itertools",
  "regex",
  "structopt",
+ "syn",
  "toml",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
@@ -58,6 +60,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "heck"
@@ -70,11 +78,20 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -85,21 +102,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -110,40 +127,38 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -153,15 +168,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 
 [[package]]
 name = "strsim"
@@ -195,24 +210,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.18"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
+checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -244,39 +248,39 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ required-features = ["cli"]
 regex = "1.3"
 structopt = { version = "0.3", optional = true }
 toml = "0.5"
+syn = "1.0.50"
+itertools = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Disneyland Parc experience, but less exciting).
     it will generate newlines with CRLF.
   - `-c --check`: check whether the *readme* is synchronized.
 
+## Intra-link support
+
+This tool rewrites intra-links so they point at the corresponding place in [docs.rs](https://docs.rs).
+At this point only intra-links of the form `[⋯](crate::⋯)` are supported.
+
 ## Q/A and troubleshooting
 
 ### Are workspace crates supported?

--- a/src/intralinks.rs
+++ b/src/intralinks.rs
@@ -1,0 +1,960 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use syn::export::fmt::Display;
+use syn::export::{Debug, Formatter};
+use syn::Ident;
+use syn::Item;
+
+#[derive(Debug)]
+pub enum IntraLinkError {
+  IOError(std::io::Error),
+  ParseError(syn::Error),
+  NoModuleFile(String, PathBuf),
+}
+
+impl fmt::Display for IntraLinkError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match self {
+      IntraLinkError::IOError(err) => write!(f, "IO error: {}", err),
+      IntraLinkError::ParseError(err) => write!(f, "Failed to parse rust file: {}", err),
+      IntraLinkError::NoModuleFile(module, dir) => write!(
+        f,
+        "Unable to find module file for module {} in directory {:?}",
+        module, dir
+      ),
+    }
+  }
+}
+
+impl From<std::io::Error> for IntraLinkError {
+  fn from(err: std::io::Error) -> Self {
+    IntraLinkError::IOError(err)
+  }
+}
+
+impl From<syn::Error> for IntraLinkError {
+  fn from(err: syn::Error) -> Self {
+    IntraLinkError::ParseError(err)
+  }
+}
+
+fn file_ast<P: AsRef<Path>>(filepath: P) -> Result<syn::File, IntraLinkError> {
+  let src = std::fs::read_to_string(filepath)?;
+
+  Ok(syn::parse_file(&src)?)
+}
+
+/// Determines the module filename, which can be `<module>.rs` or `<module>/mod.rs`.
+fn module_filename(dir: &Path, module: &Ident) -> Option<PathBuf> {
+  let mod_file = dir.join(format!("{}.rs", module));
+
+  if mod_file.is_file() {
+    return Some(mod_file);
+  }
+
+  let mod_file = dir.join(module.to_string()).join("mod.rs");
+
+  if mod_file.is_file() {
+    return Some(mod_file);
+  }
+
+  None
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum FQIdentifierAnchor {
+  Root,
+  Crate,
+}
+
+/// Fully qualified identifier.
+#[derive(Clone)]
+pub struct FQIdentifier {
+  pub anchor: FQIdentifierAnchor,
+
+  /// This path vector can be shared and can end after the identifier we are representing.
+  /// This allow us to have a faster implementation for `FQIdentifier::all_ancestors()`.
+  path_shared: Rc<Vec<String>>,
+  path_end: usize,
+}
+
+impl FQIdentifier {
+  fn new(anchor: FQIdentifierAnchor) -> FQIdentifier {
+    FQIdentifier {
+      anchor,
+      path_shared: Rc::new(Vec::new()),
+      path_end: 0,
+    }
+  }
+
+  fn from_string(s: &str) -> Option<FQIdentifier> {
+    let anchor;
+    let rest;
+
+    if s == "::" {
+      return Some(FQIdentifier::new(FQIdentifierAnchor::Root));
+    } else if s.starts_with("::") {
+      anchor = FQIdentifierAnchor::Root;
+      rest = &s[2..];
+    } else if s == "crate" {
+      return Some(FQIdentifier::new(FQIdentifierAnchor::Crate));
+    } else if s.starts_with("crate::") {
+      anchor = FQIdentifierAnchor::Crate;
+      rest = &s[7..];
+    } else {
+      return None;
+    }
+
+    if rest.is_empty() {
+      return None;
+    }
+
+    let path: Rc<Vec<String>> = Rc::new(rest.split("::").map(str::to_owned).collect());
+
+    Some(FQIdentifier {
+      anchor,
+      path_end: path.len(),
+      path_shared: path,
+    })
+  }
+
+  fn path(&self) -> &[String] {
+    &self.path_shared[0..self.path_end]
+  }
+
+  fn parent(mut self) -> Option<FQIdentifier> {
+    match self.path_end {
+      0 => None,
+      _ => {
+        self.path_end -= 1;
+        Some(self)
+      }
+    }
+  }
+
+  fn join(mut self, s: &str) -> FQIdentifier {
+    Rc::make_mut(&mut self.path_shared).push(s.to_string());
+    self.path_end += 1;
+    self
+  }
+
+  fn all_ancestors(&self) -> impl Iterator<Item = FQIdentifier> {
+    let first_ancestor = self.clone().parent();
+
+    std::iter::successors(first_ancestor, |ancestor| ancestor.clone().parent())
+  }
+}
+
+impl PartialEq for FQIdentifier {
+  fn eq(&self, other: &Self) -> bool {
+    self.anchor == other.anchor && self.path() == other.path()
+  }
+}
+
+impl Eq for FQIdentifier {}
+
+impl Hash for FQIdentifier {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.anchor.hash(state);
+    self.path().hash(state);
+  }
+}
+
+impl Display for FQIdentifier {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    match self.anchor {
+      FQIdentifierAnchor::Root => (),
+      FQIdentifierAnchor::Crate => f.write_str("crate")?,
+    }
+
+    for s in self.path().iter() {
+      f.write_str("::")?;
+      f.write_str(&s)?;
+    }
+
+    Ok(())
+  }
+}
+
+impl Debug for FQIdentifier {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    Display::fmt(self, f)
+  }
+}
+
+fn traverse_module(
+  ast: &Vec<Item>,
+  dir: &Path,
+  mod_symbol: FQIdentifier,
+  asts: &mut HashMap<FQIdentifier, Vec<Item>>,
+  explore_module: &impl Fn(&FQIdentifier) -> bool,
+) -> Result<(), IntraLinkError> {
+  if !explore_module(&mod_symbol) {
+    return Ok(());
+  }
+
+  asts.insert(mod_symbol.clone(), ast.clone());
+
+  for item in ast.iter() {
+    if let Item::Mod(module) = item {
+      let module_symbol: FQIdentifier = mod_symbol.clone().join(&module.ident.to_string());
+
+      match &module.content {
+        Some((_, items)) => {
+          traverse_module(&items, dir, module_symbol, asts, explore_module)?;
+        }
+        None if explore_module(&module_symbol) => {
+          let mod_filename = match module_filename(dir, &module.ident) {
+            None => Err(IntraLinkError::NoModuleFile(
+              module.ident.to_string(),
+              dir.to_path_buf(),
+            )),
+            Some(f) => Ok(f),
+          }?;
+
+          traverse_file(mod_filename, module_symbol, asts, explore_module)?;
+        }
+        None => (),
+      }
+    }
+  }
+
+  Ok(())
+}
+
+fn traverse_file<P: AsRef<Path>>(
+  file: P,
+  mod_symbol: FQIdentifier,
+  asts: &mut HashMap<FQIdentifier, Vec<Item>>,
+  explore_module: &impl Fn(&FQIdentifier) -> bool,
+) -> Result<(), IntraLinkError> {
+  let dir: &Path = file.as_ref().parent().expect(&format!(
+    "failed to get directory of \"{:?}\"",
+    file.as_ref()
+  ));
+  let ast: syn::File = file_ast(&file)?;
+
+  traverse_module(&ast.items, dir, mod_symbol, asts, explore_module)
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SymbolType {
+  Crate,
+  Struct,
+  Trait,
+  Enum,
+  Union,
+  Type,
+  Mod,
+  Macro,
+  Const,
+  Fn,
+  Static,
+}
+
+fn symbols_type(asts: &HashMap<FQIdentifier, Vec<Item>>) -> HashMap<FQIdentifier, SymbolType> {
+  let mut symbols_type: HashMap<FQIdentifier, SymbolType> = HashMap::new();
+
+  for (mod_symbol, ast) in asts.iter() {
+    if *mod_symbol == FQIdentifier::new(FQIdentifierAnchor::Crate) {
+      symbols_type.insert(
+        FQIdentifier::new(FQIdentifierAnchor::Crate),
+        SymbolType::Crate,
+      );
+    }
+
+    for item in ast {
+      let mut symb_type: Option<(String, SymbolType)> = None;
+
+      match item {
+        Item::Enum(e) => {
+          symb_type = Some((e.ident.to_string(), SymbolType::Enum));
+        }
+        Item::Struct(s) => {
+          symb_type = Some((s.ident.to_string(), SymbolType::Struct));
+        }
+        Item::Trait(t) => {
+          symb_type = Some((t.ident.to_string(), SymbolType::Trait));
+        }
+        Item::Union(u) => {
+          symb_type = Some((u.ident.to_string(), SymbolType::Union));
+        }
+        Item::Type(t) => {
+          symb_type = Some((t.ident.to_string(), SymbolType::Type));
+        }
+        Item::Mod(m) => {
+          symb_type = Some((m.ident.to_string(), SymbolType::Mod));
+        }
+        Item::Macro(syn::ItemMacro {
+          ident: Some(ident), ..
+        }) => {
+          symb_type = Some((ident.to_string(), SymbolType::Macro));
+        }
+        Item::Macro2(m) => {
+          symb_type = Some((m.ident.to_string(), SymbolType::Macro));
+        }
+        Item::Const(c) => {
+          symb_type = Some((c.ident.to_string(), SymbolType::Const));
+        }
+        Item::Fn(f) => {
+          symb_type = Some((f.sig.ident.to_string(), SymbolType::Fn));
+        }
+        Item::Static(s) => {
+          symb_type = Some((s.ident.to_string(), SymbolType::Static));
+        }
+
+        _ => (),
+      }
+
+      if let Some((ident, typ)) = symb_type {
+        symbols_type.insert(mod_symbol.clone().join(&ident), typ);
+      }
+    }
+  }
+
+  symbols_type
+}
+
+pub fn crate_symbols_type<P: AsRef<Path>>(
+  entry_point: P,
+  explore_module: impl Fn(&FQIdentifier) -> bool,
+) -> Result<HashMap<FQIdentifier, SymbolType>, IntraLinkError> {
+  let mut asts: HashMap<FQIdentifier, Vec<Item>> = HashMap::new();
+
+  traverse_file(
+    entry_point,
+    FQIdentifier::new(FQIdentifierAnchor::Crate),
+    &mut asts,
+    &explore_module,
+  )?;
+
+  Ok(symbols_type(&asts))
+}
+
+/// Create a set with all supermodules in `symbols`.  For instance, if `symbols` is
+/// `{crate::foo::bar::baz, crate::baz::mumble}` it will return
+/// `{crate, crate::foo, crate::foo::bar, crate::baz}`.
+pub fn all_supermodules<'a>(
+  symbols: impl Iterator<Item = &'a FQIdentifier>,
+) -> HashSet<FQIdentifier> {
+  symbols
+    .into_iter()
+    .flat_map(|s| s.all_ancestors())
+    .collect()
+}
+
+#[derive(Eq, PartialEq, Debug)]
+enum MarkdownLink<'a> {
+  /// Links like [ref], or [text][ref].
+  Ref {
+    text: Option<&'a str>,
+    reference: &'a str,
+  },
+  /// Links like [text](link).
+  Inline { text: &'a str, link: &'a str },
+}
+
+fn split_link_fragment<'a>(link: &'a str) -> (&'a str, &'a str) {
+  match link.find('#') {
+    None => (link, ""),
+    Some(i) => link.split_at(i),
+  }
+}
+
+struct MarkdownLinkIterator<'a> {
+  source: &'a str,
+  iter: std::iter::Enumerate<std::str::Bytes<'a>>,
+}
+
+impl<'a> MarkdownLinkIterator<'a> {
+  fn new(source: &'a str) -> MarkdownLinkIterator<'a> {
+    MarkdownLinkIterator {
+      source,
+      iter: source.bytes().enumerate(),
+    }
+  }
+}
+
+#[derive(Eq, PartialEq, Debug)]
+pub struct Span {
+  pub start: usize,
+  pub end: usize,
+}
+
+impl<'a> Iterator for MarkdownLinkIterator<'a> {
+  type Item = (Span, MarkdownLink<'a>);
+
+  fn next(&mut self) -> Option<Self::Item> {
+    let mut escape = 0;
+    let mut state = 0;
+    let mut nest_level = 0;
+    let mut start: Option<usize> = None;
+    let mut first_component: Option<&str> = None;
+
+    // This works well with UTF-8 because we just look for symbols that are ASCII, which means
+    // they start with a 0 bit.  In UTF-8 codepoints that start with a 0 bit are ASCII codepoints,
+    // which means that when we match some specific char in the loop below we actually know for
+    // sure we are dealing with the right symbol.
+
+    while let Some((i, c)) = self.iter.next() {
+      match c {
+        _ if escape > 0 => escape -= 1,
+        b'\\' => escape = 1,
+
+        b'[' if state == 0 => {
+          state = 1;
+          start = Some(i);
+        }
+
+        b'[' if state == 1 => nest_level += 1,
+        b']' if state == 1 && nest_level > 0 => nest_level -= 1,
+        b']' if state == 1 => {
+          state = 2;
+          first_component = Some(&self.source[start.unwrap() + 1..i]);
+        }
+
+        b'(' if state == 2 => state = 3,
+        b'[' if state == 2 => state = 4,
+        _ if state == 2 => {
+          let span = Span {
+            start: start.unwrap(),
+            end: i,
+          };
+          return Some((
+            span,
+            MarkdownLink::Ref {
+              text: None,
+              reference: first_component.unwrap(),
+            },
+          ));
+        }
+
+        b'(' if state == 3 => nest_level += 1,
+        b')' if state == 3 && nest_level > 0 => nest_level -= 1,
+        b')' if state == 3 => {
+          let span = Span {
+            start: start.unwrap(),
+            end: i + 1,
+          };
+          let text = first_component.unwrap();
+          let link = &self.source[start.unwrap() + text.len() + 3..i];
+          return Some((span, MarkdownLink::Inline { text, link }));
+        }
+
+        b'[' if state == 4 => nest_level += 1,
+        b']' if state == 4 && nest_level > 0 => nest_level -= 1,
+        b']' if state == 4 => {
+          let span = Span {
+            start: start.unwrap(),
+            end: i + 1,
+          };
+          let text = first_component.unwrap();
+          let reference = &self.source[start.unwrap() + text.len() + 3..i];
+          return Some((
+            span,
+            MarkdownLink::Ref {
+              text: Some(text),
+              reference,
+            },
+          ));
+        }
+
+        _ => (),
+      }
+    }
+
+    None
+  }
+}
+
+pub fn extract_markdown_intralink_symbols(doc: &str) -> HashSet<FQIdentifier> {
+  let mut symbols = HashSet::new();
+
+  for (_, link) in MarkdownLinkIterator::new(doc) {
+    if let MarkdownLink::Inline { link, .. } = link {
+      let (link, _) = split_link_fragment(link);
+
+      if let Some(symbol) = FQIdentifier::from_string(&link) {
+        if let FQIdentifierAnchor::Crate = symbol.anchor {
+          symbols.insert(symbol);
+        }
+      }
+    }
+  }
+
+  symbols
+}
+
+fn documentation_url(symbol: &FQIdentifier, typ: SymbolType, crate_name: &str) -> String {
+  let mut link = format!("https://docs.rs/{}/latest/{}/", crate_name, crate_name);
+
+  if SymbolType::Crate == typ {
+    return link;
+  }
+
+  for s in symbol.path().iter().rev().skip(1).rev() {
+    link.push_str(s);
+    link.push('/');
+  }
+
+  let name = symbol
+    .path()
+    .last()
+    .expect(&format!("failed to get last component of {}", symbol));
+
+  match typ {
+    SymbolType::Crate => unreachable!(),
+    SymbolType::Struct => link.push_str(&format!("struct.{}.html", name)),
+    SymbolType::Trait => link.push_str(&format!("trait.{}.html", name)),
+    SymbolType::Enum => link.push_str(&format!("enum.{}.html", name)),
+    SymbolType::Union => link.push_str(&format!("union.{}.html", name)),
+    SymbolType::Type => link.push_str(&format!("type.{}.html", name)),
+    SymbolType::Mod => link.push_str(&format!("{}/", name)),
+    SymbolType::Macro => link.push_str(&format!("macro.{}.html", name)),
+    SymbolType::Const => link.push_str(&format!("const.{}.html", name)),
+    SymbolType::Fn => link.push_str(&format!("fn.{}.html", name)),
+    SymbolType::Static => link.push_str(&format!("static.{}.html", name)),
+  }
+
+  link
+}
+
+pub fn rewrite_markdown_links(
+  doc: &str,
+  symbols_type: &HashMap<FQIdentifier, SymbolType>,
+  crate_name: &str,
+  mut emit_warning: impl FnMut(&str),
+) -> String {
+  let mut new_doc = String::with_capacity(doc.len());
+  let mut last_span = Span { start: 0, end: 0 };
+
+  for (span, link) in MarkdownLinkIterator::new(doc) {
+    new_doc.push_str(&doc[last_span.end..span.start]);
+
+    match link {
+      MarkdownLink::Ref {
+        text: None,
+        reference,
+      } => new_doc.push_str(&format!("[{}]", reference)),
+      MarkdownLink::Ref {
+        text: Some(t),
+        reference,
+      } => new_doc.push_str(&format!("[{}][{}]", t, reference)),
+      MarkdownLink::Inline { text, link } => {
+        let (link, fragment): (&str, &str) = split_link_fragment(link);
+
+        match FQIdentifier::from_string(&link) {
+          Some(symbol) if symbols_type.contains_key(&symbol) => {
+            let typ = symbols_type[&symbol];
+            let new_link = documentation_url(&symbol, typ, crate_name);
+
+            new_doc.push_str(&format!("[{}]({}{})", text, new_link, fragment));
+          }
+          r => {
+            if let Some(symbol) = r {
+              match symbol.anchor {
+                FQIdentifierAnchor::Root => {
+                  emit_warning(&format!(
+                    "Absolute intra-links are not yet supported.  Skipping `{}`.",
+                    symbol
+                  ));
+                }
+                FQIdentifierAnchor::Crate => {
+                  emit_warning(&format!("Could not find `{}` in the code.", symbol));
+                }
+              }
+            }
+
+            new_doc.push_str(&format!("[{}]({}{})", text, link, fragment));
+          }
+        }
+      }
+    }
+
+    last_span = span;
+  }
+
+  new_doc.push_str(&doc[last_span.end..]);
+
+  new_doc
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_markdown_link_iterator() {
+    let markdown = "A [some text] [another](http://foo.com), [another][one]";
+
+    let mut iter = MarkdownLinkIterator::new(&markdown);
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: None,
+        reference: &"some text"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[some text]");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Inline {
+        text: &"another",
+        link: &"http://foo.com"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another](http://foo.com)");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: Some(&"another"),
+        reference: &"one"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another][one]");
+
+    assert_eq!(iter.next(), None);
+
+    let markdown = "[another](http://foo.com)[another][one]";
+
+    let mut iter = MarkdownLinkIterator::new(&markdown);
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Inline {
+        text: &"another",
+        link: &"http://foo.com"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another](http://foo.com)");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: Some(&"another"),
+        reference: &"one"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another][one]");
+
+    assert_eq!(iter.next(), None);
+
+    let markdown = "A [some [text]], [another [text] (foo)](http://foo.com/foo(bar)), [another [] one][foo[]bar]";
+
+    let mut iter = MarkdownLinkIterator::new(&markdown);
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: None,
+        reference: &"some [text]"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[some [text]]");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Inline {
+        text: &"another [text] (foo)",
+        link: &"http://foo.com/foo(bar)"
+      }
+    );
+    assert_eq!(
+      &markdown[start..end],
+      "[another [text] (foo)](http://foo.com/foo(bar))"
+    );
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: Some(&"another [] one"),
+        reference: &"foo[]bar"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another [] one][foo[]bar]");
+
+    assert_eq!(iter.next(), None);
+
+    let markdown = "A [some \\]text], [another](http://foo.com\\)), [another\\]][one\\]]";
+
+    let mut iter = MarkdownLinkIterator::new(&markdown);
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: None,
+        reference: &"some \\]text"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[some \\]text]");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Inline {
+        text: &"another",
+        link: &"http://foo.com\\)"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another](http://foo.com\\))");
+
+    let (Span { start, end }, link) = iter.next().unwrap();
+    assert_eq!(
+      link,
+      MarkdownLink::Ref {
+        text: Some(&"another\\]"),
+        reference: &"one\\]"
+      }
+    );
+    assert_eq!(&markdown[start..end], "[another\\]][one\\]]");
+
+    assert_eq!(iter.next(), None);
+  }
+
+  #[test]
+  fn test_all_supermodules() {
+    let symbols = [
+      FQIdentifier::from_string("crate::foo::bar::baz").unwrap(),
+      FQIdentifier::from_string("crate::baz::mumble").unwrap(),
+    ];
+    let expected: HashSet<FQIdentifier> = [
+      FQIdentifier::from_string("crate").unwrap(),
+      FQIdentifier::from_string("crate::foo").unwrap(),
+      FQIdentifier::from_string("crate::foo::bar").unwrap(),
+      FQIdentifier::from_string("crate::baz").unwrap(),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    assert_eq!(all_supermodules(symbols.iter()), expected);
+  }
+
+  #[test]
+  fn test_traverse_module_and_symbols_type() {
+    let mut asts: HashMap<FQIdentifier, Vec<Item>> = HashMap::new();
+    let module_skip: FQIdentifier = FQIdentifier::from_string("crate::skip").unwrap();
+
+    let source = "
+        struct AStruct {}
+
+        mod skip {
+          struct Skip {}
+        }
+
+        mod a {
+          mod b {
+            trait ATrait {}
+          }
+
+          struct FooStruct {}
+        }
+        ";
+
+    traverse_module(
+      &syn::parse_file(&source).unwrap().items,
+      &PathBuf::new(),
+      FQIdentifier::new(FQIdentifierAnchor::Crate),
+      &mut asts,
+      &|m| *m != module_skip,
+    )
+    .ok()
+    .unwrap();
+
+    let symbols_type: HashMap<FQIdentifier, SymbolType> = symbols_type(&asts);
+    let expected: HashMap<FQIdentifier, SymbolType> = [
+      (
+        FQIdentifier::from_string("crate").unwrap(),
+        SymbolType::Crate,
+      ),
+      (
+        FQIdentifier::from_string("crate::AStruct").unwrap(),
+        SymbolType::Struct,
+      ),
+      (
+        FQIdentifier::from_string("crate::skip").unwrap(),
+        SymbolType::Mod,
+      ),
+      (
+        FQIdentifier::from_string("crate::a").unwrap(),
+        SymbolType::Mod,
+      ),
+      (
+        FQIdentifier::from_string("crate::a::b").unwrap(),
+        SymbolType::Mod,
+      ),
+      (
+        FQIdentifier::from_string("crate::a::b::ATrait").unwrap(),
+        SymbolType::Trait,
+      ),
+      (
+        FQIdentifier::from_string("crate::a::FooStruct").unwrap(),
+        SymbolType::Struct,
+      ),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    assert_eq!(symbols_type, expected)
+  }
+
+  #[test]
+  fn test_traverse_module_expore_lazily() {
+    let symbols: HashSet<FQIdentifier> = [FQIdentifier::from_string("crate::module").unwrap()]
+      .iter()
+      .cloned()
+      .collect();
+    let modules = all_supermodules(symbols.iter());
+
+    let mut asts: HashMap<FQIdentifier, Vec<Item>> = HashMap::new();
+
+    let source = "
+        mod module {
+          struct Foo {}
+        }
+        ";
+
+    traverse_module(
+      &syn::parse_file(&source).unwrap().items,
+      &PathBuf::new(),
+      FQIdentifier::new(FQIdentifierAnchor::Crate),
+      &mut asts,
+      &|module| modules.contains(module),
+    )
+    .ok()
+    .unwrap();
+
+    let symbols_type: HashSet<FQIdentifier> = symbols_type(&asts).keys().cloned().collect();
+
+    // We should still get `crate::module`, but nothing inside it.
+    let expected: HashSet<FQIdentifier> = [
+      FQIdentifier::from_string("crate").unwrap(),
+      FQIdentifier::from_string("crate::module").unwrap(),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    assert_eq!(symbols_type, expected);
+  }
+
+  #[test]
+  fn test_documentation_url() {
+    let link = documentation_url(
+      &FQIdentifier::from_string("crate").unwrap(),
+      SymbolType::Crate,
+      "foobini",
+    );
+    assert_eq!(link, "https://docs.rs/foobini/latest/foobini/");
+
+    let link = documentation_url(
+      &FQIdentifier::from_string("crate::AStruct").unwrap(),
+      SymbolType::Struct,
+      "foobini",
+    );
+    assert_eq!(
+      link,
+      "https://docs.rs/foobini/latest/foobini/struct.AStruct.html"
+    );
+
+    let link = documentation_url(
+      &FQIdentifier::from_string("crate::amodule").unwrap(),
+      SymbolType::Mod,
+      "foobini",
+    );
+    assert_eq!(link, "https://docs.rs/foobini/latest/foobini/amodule/");
+  }
+
+  #[test]
+  fn test_extract_markdown_intralink_symbols() {
+    let doc = "
+        # Foobini
+
+        This [this crate](crate) is cool because it contains [modules](crate::amodule) and some
+        other [stuff](https://en.wikipedia.org/wiki/Stuff) as well.
+
+        Go ahead and check all the [structs in foo](crate::foo#structs)
+        ";
+
+    let symbols = extract_markdown_intralink_symbols(doc);
+
+    let expected: HashSet<FQIdentifier> = [
+      FQIdentifier::from_string("crate").unwrap(),
+      FQIdentifier::from_string("crate::amodule").unwrap(),
+      FQIdentifier::from_string("crate::foo").unwrap(),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    assert_eq!(symbols, expected);
+  }
+
+  #[test]
+  fn test_rewrite_markdown_links() {
+    let doc = "
+        # Foobini
+
+        This [this crate](crate) is cool because it contains [modules](crate::amodule) and some
+        other [stuff](https://en.wikipedia.org/wiki/Stuff) as well.
+
+        This link is [broken](crate::broken) and this is [not supported](::foo::bar).
+
+        Go ahead and check all the [structs in foo](crate::foo#structs) specifically
+        [this one](crate::foo::BestStruct)
+        ";
+
+    let symbols_type: HashMap<FQIdentifier, SymbolType> = [
+      (
+        FQIdentifier::from_string("crate").unwrap(),
+        SymbolType::Crate,
+      ),
+      (
+        FQIdentifier::from_string("crate::amodule").unwrap(),
+        SymbolType::Mod,
+      ),
+      (
+        FQIdentifier::from_string("crate::foo").unwrap(),
+        SymbolType::Mod,
+      ),
+      (
+        FQIdentifier::from_string("crate::foo::BestStruct").unwrap(),
+        SymbolType::Struct,
+      ),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let new_readme = rewrite_markdown_links(&doc, &symbols_type, "foobini", |_| ());
+    let expected = "
+        # Foobini
+
+        This [this crate](https://docs.rs/foobini/latest/foobini/) is cool because it contains [modules](https://docs.rs/foobini/latest/foobini/amodule/) and some
+        other [stuff](https://en.wikipedia.org/wiki/Stuff) as well.
+
+        This link is [broken](crate::broken) and this is [not supported](::foo::bar).
+
+        Go ahead and check all the [structs in foo](https://docs.rs/foobini/latest/foobini/foo/#structs) specifically
+        [this one](https://docs.rs/foobini/latest/foobini/foo/struct.BestStruct.html)
+        ";
+
+    assert_eq!(new_readme, expected);
+  }
+}


### PR DESCRIPTION
Initial support for intralinks paths of the form `crate::⋯`.  I intend to add support for `std::⋯` in another PR.
